### PR TITLE
[FIX] : 🔧(LoginActivity): 

### DIFF
--- a/app/src/main/java/com/example/android_supporters_sns_project/LoginActivity.kt
+++ b/app/src/main/java/com/example/android_supporters_sns_project/LoginActivity.kt
@@ -3,6 +3,8 @@ package com.example.android_supporters_sns_project
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.view.MotionEvent
+import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
@@ -109,6 +111,13 @@ class LoginActivity : AppCompatActivity() {
             passwordWarningMessage.text = getString(R.string.login_passwordEnterMessage)
             passwordWarningMessage.visibility = TextView.VISIBLE
         }
+    }
+
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        val imm: InputMethodManager =
+            getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(currentFocus?.windowToken, 0)
+        return super.dispatchTouchEvent(ev)
     }
 
 }


### PR DESCRIPTION
화면이 좁은 기종은 스크롤 뷰를 쓴다고 해도 회원가입 버튼을 키보드를 숨겨야만 가능한데 
회원가입처럼 바깥 화면 클릭 시 키보드가 숨기게 구현함